### PR TITLE
Make the extension borrow the default style colour

### DIFF
--- a/styles/prosilver/template/index_flags.html
+++ b/styles/prosilver/template/index_flags.html
@@ -8,7 +8,7 @@
 			</dl>
 		</li>
 	</ul>
-	<ul class="flags">
+	<ul class="flags forums">
 	<!-- BEGIN flag -->
 		<li class="bg1 flagslist">
 			<a href="{flag.U_FLAG}">{flag.FLAG}</a><br />{flag.FLAG_USERS}


### PR DESCRIPTION
Adding the .forums class, makes the extension inherit the background colour of the current board style. I'd appreciate if you'd accept the change. 

The background colours from ul.flags { and div.flags { paths should be removed. 
Im not sure where the div.flags one is used yet.
